### PR TITLE
Change the url of v2ray install script & simplify the rule of client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ wget -N --no-check-certificate -q -O install.sh "https://raw.githubusercontent.c
 **注意**: 
 1. 脚本默认使用最新的Core, 请注意客户端 Core 的同步更新，需要保证客户端内核版本 >= 服务端内核版本
 2. 确保入站80端口和自己所需的端口已经打开. 比如使用微软的云服务，NSG需要允许所需端口.
-3. 由于 [websocket: close 1000 (normal) > proxy/vmess/encoding: invalid user > proxy/vmess: Not Found](https://github.com/v2fly/v2ray-core/issues/1605), 使用固定的v2ray社区安转脚本(commit: 224e431). 如果问题解决, 可自行升级最新社区安装脚本
-4. 使用yaml配置文件的时候(针对ClashX Pro), 需要把ruleset里的配置文件一起保存到本地
+3. 使用yaml配置文件的时候(针对ClashX Pro), 需要把ruleset里的配置文件一起保存到本地
 
 ### 更新日志
 

--- a/install.sh
+++ b/install.sh
@@ -249,7 +249,7 @@ port_alterid_set() {
 
 modify_path() {
     sed -i "/\"path\"/c \\\t  \"path\":\"${camouflage}\"" ${v2ray_conf}
-    sed -i "99c \"path\": \"${camouflage}\"," "${v2ray_client_config_json}"
+    sed -i "/\"path\"/c \"path\": \"${camouflage}\"," "${v2ray_client_config_json}"
     sed -i "60c \ \ \ \ path: ${camouflage}" "${v2ray_client_config_yaml}"
     judge "V2ray 伪装路径 修改"
 }
@@ -266,7 +266,7 @@ modify_alterid() {
     fi
 
     sed -i "/\"alterId\"/c \\\t  \"alterId\":${alterID}" ${v2ray_conf}
-    sed -i "86c \"alterId\": ${alterID}," "${v2ray_client_config_json}"
+    sed -i "/\"alterId\"/c \"alterId\": ${alterID}," "${v2ray_client_config_json}"
     sed -i "52c \ \ alterId: ${alterID}" "${v2ray_client_config_yaml}"
     judge "V2ray alterid 修改"
     echo -e "${OK} ${GreenBG} alterID:${alterID} ${Font}"
@@ -281,7 +281,7 @@ modify_inbound_port() {
 modify_UUID() {
     [ -z "$UUID" ] && UUID=$(cat /proc/sys/kernel/random/uuid)
     sed -i "/\"id\"/c \\\t  \"id\":\"${UUID}\"," ${v2ray_conf}
-    sed -i "85c \"id\": \"${UUID}\"," "${v2ray_client_config_json}"
+    sed -i "/\"id\"/c \"id\": \"${UUID}\"," "${v2ray_client_config_json}"
     sed -i "51c \ \ uuid: ${UUID}" "${v2ray_client_config_yaml}"
     judge "V2ray UUID 修改"
     echo -e "${OK} ${GreenBG} UUID:${UUID} ${Font}"
@@ -290,7 +290,7 @@ modify_UUID() {
 modify_nginx_port() {
     sed -i "/ssl http2;$/c \\\tlisten ${port} ssl http2;" ${nginx_conf}
     sed -i "3c \\\tlisten [::]:${port} http2;" ${nginx_conf}
-    sed -i "82c \"port\": ${port}," "${v2ray_client_config_json}"
+    sed -i "/\"port\": 123456789/c \"port\": ${port}," "${v2ray_client_config_json}"
     sed -i "50c \ \ port: ${port}" "${v2ray_client_config_yaml}"
     judge "V2ray port 修改"
     echo -e "${OK} ${GreenBG} 端口号:${port} ${Font}"
@@ -321,7 +321,7 @@ v2ray_install() {
     fi
     mkdir -p /root/v2ray
     cd /root/v2ray || exit
-    wget --no-check-certificate "https://raw.githubusercontent.com/taurusni/V2ray_tls_ws/${github_branch}/v2fly_224e431/install-release.sh"
+    wget --no-check-certificate "https://raw.githubusercontent.com/v2fly/fhs-install-v2ray/${github_branch}/install-release.sh"
 
     if [[ -f install-release.sh ]]; then
         rm -rf $v2ray_systemd_file
@@ -662,7 +662,7 @@ ssl_judge_and_install() {
         read -r ssl_delete
         case $ssl_delete in
             [yY][eE][sS] | [yY])
-                rm -rf /data/*
+                rm -rf ${v2ray_ssl_path}/*
                 echo -e "${OK} ${GreenBG} 已删除 ${Font}"
                 ;;
             *) ;;
@@ -878,8 +878,8 @@ modify_camouflage_path() {
     [[ -z ${camouflage_path} ]] && camouflage_path=1
     sed -i "/location/c \\\tlocation \/${camouflage_path}\/" ${nginx_conf}          # Modify the camouflage path of the nginx configuration file
     sed -i "/\"path\"/c \\\t  \"path\": \"\/${camouflage_path}\/\"" ${v2ray_conf}   # Modify the camouflage path of the v2ray server configuration file
-    sed -i "99c \"path\": \"${camouflage}\"," "${v2ray_client_config_json}"         # Modify the camouflage path of the v2ray client configuration file
-    sed -i "60c \ \ \ \ path: ${camouflage}" "${v2ray_client_config_yaml}"          # Modify the camouflage path of the v2ray client configuration file
+    sed -i "/\"path\"/c \"path\": \"${camouflage_path}\"," "${v2ray_client_config_json}"         # Modify the camouflage path of the v2ray client configuration file
+    sed -i "60c \ \ \ \ path: ${camouflage_path}" "${v2ray_client_config_yaml}"          # Modify the camouflage path of the v2ray client configuration file
     judge "V2ray camouflage path modified"
 }
 

--- a/tls/client_config.json
+++ b/tls/client_config.json
@@ -2,43 +2,6 @@
     "log": {
         "loglevel": "warning"
     },
-    "dns": {
-        "hosts": {
-            "dns.google": "8.8.8.8",
-            "dns.pub": "119.29.29.29",
-            "dns.alidns.com": "223.5.5.5",
-            "geosite:category-ads-all": "127.0.0.1"
-        },
-        "servers": [
-            {
-                "address": "https://1.1.1.1/dns-query",
-                "domains": [
-                    "geosite:geolocation-!cn",
-                    "geosite:google@cn"
-                ],
-                "expectIPs": [
-                    "geoip:!cn"
-                ]
-            },
-            "8.8.8.8",
-            {
-                "address": "114.114.114.114",
-                "port": 53,
-                "domains": [
-                    "geosite:cn",
-                    "geosite:category-games@cn"
-                ],
-                "expectIPs": [
-                    "geoip:cn"
-                ],
-                "skipFallback": true
-            },
-            {
-                "address": "localhost",
-                "skipFallback": true
-            }
-        ]
-    },
     "inbounds": [
         {
             "protocol": "socks",
@@ -112,100 +75,52 @@
             }
         },
         {
-            "protocol": "dns",
-            "tag": "dns-out"
-        },
-        {
             "protocol": "freedom",
             "tag": "direct",
             "settings": {
                 "domainStrategy": "UseIP"
             }
-        },
-        {
-            "protocol": "blackhole",
-            "tag": "reject",
-            "settings": {
-                "response": {
-                    "type": "http"
-                }
-            }
         }
     ],
     "routing": {
-        "domainStrategy": "IPIfNonMatch",
+        "domainStrategy": "IPOnDemand",
         "domainMatcher": "mph",
         "rules": [
             {
                 "type": "field",
                 "outboundTag": "direct",
-                "protocol": [
-                    "bittorrent"
-                ]
-            },
-            {
-                "type": "field",
-                "outboundTag": "dns-out",
-                "inboundTag": [
-                    "socks-in",
-                    "http-in"
-                ],
-                "network": "udp",
-                "port": 53
-            },
-            {
-                "type": "field",
-                "outboundTag": "reject",
                 "domain": [
-                    "geosite:category-ads-all"
+                    "msn",
+                    "live",
+                    "microsoft",
+                    "azureedge",
+                    "bing",
+                    "scorecardresearch"
                 ]
             },
             {
                 "type": "field",
                 "outboundTag": "proxy",
                 "domain": [
-                    "full:www.icloud.com",
-                    "domain:icloud-content.com",
-                    "geosite:google"
-                ]
-            },
-            {
-                "type": "field",
-                "outboundTag": "direct",
-                "domain": [
-                    "geosite:tld-cn",
-                    "geosite:icloud",
-                    "geosite:category-games@cn"
-                ]
-            },
-            {
-                "type": "field",
-                "outboundTag": "proxy",
-                "domain": [
+                    "geosite:google",
                     "geosite:geolocation-!cn"
                 ]
             },
-            {
-                "type": "field",
-                "outboundTag": "direct",
-                "domain": [
-                    "geosite:cn",
-                    "geosite:private"
-                ]
-            },
-            {
+              {
+                  "type": "field",
+                  "outboundTag": "direct",
+                  "domain": [
+                      "geosite:cn"
+                  ]
+              },
+              {
                 "type": "field",
                 "outboundTag": "direct",
                 "ip": [
-                    "geoip:cn",
-                    "geoip:private"
-                ]
-            },
-            {
-                "type": "field",
-                "outboundTag": "proxy",
-                "network": "tcp,udp"
-            }
-        ]
+                  "geoip:cn",
+                  "geoip:private"
+                  ]
+                }
+          ]
     }
 }


### PR DESCRIPTION

1. Change the url of v2ray install_release.sh to the latest community address.
  - The old version would cause install failed as the MD5sum check fail.
2. Simplify the rule of client_config to have a better perf.
3. Small fix in install.sh to reduce the magic numble.